### PR TITLE
rename custom nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-graph"
-version = "0.2.1"
+version = "0.2.2"
 description = "'Sphinx-Graph' is a plain-text, VCS-friendly, requirements management tool."
 authors = ["Daniel Eades <danieleades@hotmail.com>"]
 license = "MIT"

--- a/src/sphinx_graph/table/__init__.py
+++ b/src/sphinx_graph/table/__init__.py
@@ -6,12 +6,12 @@ from sphinx.application import Sphinx
 from sphinx_graph.table import events
 from sphinx_graph.table.directive import Directive
 from sphinx_graph.table.info import Info
-from sphinx_graph.table.node import Node
+from sphinx_graph.table.node import TableNode
 
 __all__ = [
     "Info",
     "Directive",
-    "Node",
+    "TableNode",
     "register",
 ]
 
@@ -33,7 +33,7 @@ def depart_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
 def register(app: Sphinx) -> None:
     """Register the vertex-table node, directive, and lifecycle events."""
     app.add_node(
-        Node,
+        TableNode,
         html=(visit_node, depart_node),
         latex=(visit_node, depart_node),
         text=(visit_node, depart_node),

--- a/src/sphinx_graph/table/directive.py
+++ b/src/sphinx_graph/table/directive.py
@@ -13,7 +13,7 @@ from sphinx.util.typing import OptionSpec
 
 from sphinx_graph import parse
 from sphinx_graph.table.info import Info
-from sphinx_graph.table.node import Node
+from sphinx_graph.table.node import TableNode
 from sphinx_graph.table.state import State
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class Directive(SphinxDirective):
     def run(self) -> Sequence[nodes.Node]:
         """Run the directive and return a Vertex node."""
         uid = uuid.uuid4()
-        node = Node(graph_uid=uid)
+        node = TableNode(graph_uid=uid)
 
         toml.loads("\n".join(self.content))
 

--- a/src/sphinx_graph/table/events.py
+++ b/src/sphinx_graph/table/events.py
@@ -11,7 +11,7 @@ from sphinx.errors import ConfigError
 
 from sphinx_graph import vertex
 from sphinx_graph.format import comma_separated_list
-from sphinx_graph.table.node import Node
+from sphinx_graph.table.node import TableNode
 from sphinx_graph.table.state import State
 from sphinx_graph.vertex.events import relative_uris, vertex_reference
 from sphinx_graph.vertex.query import DEFAULT_QUERY, QUERIES
@@ -51,7 +51,7 @@ def process(app: Sphinx, doctree: nodes.document, _fromdocname: str) -> None:
     vertex_state = vertex.State.read(app.env)
     queries = QUERIES
     queries.update(app.config.graph_config.queries)
-    for node in doctree.findall(Node):
+    for node in doctree.findall(TableNode):
         uid = node["graph_uid"]
         info = state.tables[uid]
         if info.query and info.query not in queries:

--- a/src/sphinx_graph/table/node.py
+++ b/src/sphinx_graph/table/node.py
@@ -7,5 +7,5 @@ from __future__ import annotations
 from docutils import nodes
 
 
-class Node(nodes.General, nodes.Element):  # type: ignore[misc]
+class TableNode(nodes.General, nodes.Element):  # type: ignore[misc]
     """An RST node representing a Vertex."""

--- a/src/sphinx_graph/vertex/__init__.py
+++ b/src/sphinx_graph/vertex/__init__.py
@@ -1,28 +1,46 @@
 """Types and methods specific to the vertex directive."""
 
+from docutils import nodes
 from sphinx.application import Sphinx
 
 from sphinx_graph.vertex import events
 from sphinx_graph.vertex.config import Config
 from sphinx_graph.vertex.directive import Directive
 from sphinx_graph.vertex.info import Info
-from sphinx_graph.vertex.node import Node
+from sphinx_graph.vertex.node import VertexNode
 from sphinx_graph.vertex.query import Query
 from sphinx_graph.vertex.state import State
 
 __all__ = [
     "Config",
     "Info",
-    "Node",
+    "VertexNode",
     "State",
     "Query",
 ]
 
 
+def visit_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    """Visits the Vertex node.
+
+    This method is a no-op
+    """
+
+
+def depart_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    """Visits the Vertex node.
+
+    This method is a no-op
+    """
+
+
 def register(app: Sphinx) -> None:
     """Register the vertex node, directive, and events."""
     app.add_node(
-        Node,
+        VertexNode,
+        html=(visit_node, depart_node),
+        latex=(visit_node, depart_node),
+        text=(visit_node, depart_node),
     )
 
     app.add_directive("vertex", Directive)

--- a/src/sphinx_graph/vertex/directive.py
+++ b/src/sphinx_graph/vertex/directive.py
@@ -16,7 +16,7 @@ from sphinx_graph import parse
 from sphinx_graph.config import Config
 from sphinx_graph.vertex.config import Config as VertexConfig
 from sphinx_graph.vertex.info import Info
-from sphinx_graph.vertex.node import Node
+from sphinx_graph.vertex.node import VertexNode
 from sphinx_graph.vertex.state import State
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class Directive(SphinxDirective):
     def run(self) -> Sequence[nodes.Node]:
         """Run the directive and return a Vertex node."""
         uid = self.arguments[0]
-        content_node = Node(graph_uid=uid)
+        content_node = VertexNode(graph_uid=uid)
         nested_parse_with_titles(self.state, self.content, content_node)
 
         fingerprint = base64.b64encode(

--- a/src/sphinx_graph/vertex/events.py
+++ b/src/sphinx_graph/vertex/events.py
@@ -9,9 +9,9 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.environment import BuildEnvironment
 
-from sphinx_graph import vertex
 from sphinx_graph.vertex import layout
 from sphinx_graph.vertex.info import Info, InfoParsed
+from sphinx_graph.vertex.node import VertexNode
 from sphinx_graph.vertex.state import State
 
 
@@ -58,7 +58,7 @@ def process(app: Sphinx, doctree: nodes.document, _fromdocname: str) -> None:
     builder = app.builder
     with State.get(app.env) as state:
         state.build_and_check_graph()
-        for vertex_node in doctree.findall(vertex.Node):
+        for vertex_node in doctree.findall(VertexNode):
             uid = vertex_node["graph_uid"]
             info = state.vertices[uid]
             [parents, children] = [

--- a/src/sphinx_graph/vertex/layout.py
+++ b/src/sphinx_graph/vertex/layout.py
@@ -99,11 +99,9 @@ def subtle(helper: FormatHelper) -> nodes.Node:
     paragraph = nodes.paragraph()
     paragraph.append(one_liner)
 
-    element = nodes.Element()
-    element.append(paragraph)
-    element.append(helper.info.content)
+    paragraph.append(helper.info.content)
 
-    return element
+    return paragraph  # type: ignore[no-any-return]
 
 
 Formatter = Callable[[FormatHelper], nodes.Node]

--- a/src/sphinx_graph/vertex/node.py
+++ b/src/sphinx_graph/vertex/node.py
@@ -7,5 +7,5 @@ from __future__ import annotations
 from docutils import nodes
 
 
-class Node(nodes.General, nodes.Element):  # type: ignore[misc]
+class VertexNode(nodes.General, nodes.Element):  # type: ignore[misc]
     """An RST node representing a Vertex."""


### PR DESCRIPTION
attempt to rename the custom nodes as a workaround to https://github.com/sphinx-doc/sphinx/issues/11219

this appears to fail, but i'm baffled as to why. removing nesting inside a a `docutils.Element` node seems to help