### PR TITLE
chore: drop support for python 3.9

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-graph"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rustworkx" },


### PR DESCRIPTION
placeholder for dropping python 3.9 support in future