### PR TITLE
chore(ci): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,41 @@
 version: 2
 updates:
+  # Daily: Major updates and security updates
+  - package-ecosystem: "pip"
+    target-branch: "main" # Workaround to allow multiple schedules. see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    versioning-strategy: increase-if-necessary
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+
+  # Monthly: Bundle patch updates together
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    versioning-strategy: increase-if-necessary
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+  # Daily: GitHub Actions updates
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -7,11 +43,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-  - package-ecosystem: "pip"
-    directory: "/"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    schedule:
-      interval: "daily"
-    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
no point merging this before dependabot adds support for UV. leaving as a draft