### PR TITLE
fix: handle empty parent fingerprint in parser

### DIFF
--- a/src/sphinx_graph/parse.py
+++ b/src/sphinx_graph/parse.py
@@ -41,7 +41,7 @@ def parents(value: str | None) -> dict[str, str | None]:
         if ":" in token:
             subtokens = token.split(":", maxsplit=1)
             uid = subtokens[0]
-            fingerprint = subtokens[1]
+            fingerprint = subtokens[1] or None
         else:
             uid = token
             fingerprint = None

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -34,6 +34,7 @@ def test_parse_boolean(
     [
         (None, {}),
         ("REQ-01", {"REQ-01": None}),
+        ("REQ-01:", {"REQ-01": None}),
         ("REQ-01:1234", {"REQ-01": "1234"}),
         (
             "REQ-01:1234, REQ-02,REQ-03:5678",


### PR DESCRIPTION
## Summary
- treat empty parent fingerprint as missing
- test parent parsing with trailing colon

## Testing
- `PYTHONPATH=stub_pkg:. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_parse.py::test_parse_parents -q`


------
https://chatgpt.com/codex/tasks/task_e_68a993de5c44832a90980ef421294d1e