### PR TITLE
Handle invalid TOML in vertex table directive

### DIFF
--- a/tests/roots/test-table-invalid-toml/conf.py
+++ b/tests/roots/test-table-invalid-toml/conf.py
@@ -1,0 +1,3 @@
+extensions = [
+    "sphinx_graph",
+]

--- a/tests/roots/test-table-invalid-toml/index.rst
+++ b/tests/roots/test-table-invalid-toml/index.rst
@@ -1,0 +1,3 @@
+.. vertex-table::
+
+   invalid = [[

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pytest
 from sphinx.application import Sphinx
-from sphinx.errors import ConfigError
+from sphinx.errors import ConfigError, SphinxError
 
 from sphinx_graph.table.info import Info
 from sphinx_graph.table.state import State
@@ -25,6 +25,12 @@ def test_query_unknown_fails(app: Sphinx) -> None:
         ConfigError,
         match="no query registered with name 'unknown'",
     ):
+        app.build()
+
+
+@pytest.mark.sphinx(testroot="table-invalid-toml", warningiserror=True)
+def test_invalid_toml_fails(app: Sphinx) -> None:
+    with pytest.raises(SphinxError, match="vertex-table"):
         app.build()
 
 


### PR DESCRIPTION
## Summary
- add error handling for invalid TOML in the vertex-table directive
- log decoding failures with source location before raising SphinxError
- add a regression test root and test case covering malformed TOML input

## Testing
- pytest tests/test_table.py::test_invalid_toml_fails

------
https://chatgpt.com/codex/tasks/task_e_68f3f79845c4832ab1d45a58d80ef985