### PR TITLE
Fix purge to mutate temporary vertices state

### DIFF
--- a/src/sphinx_graph/vertex/state.py
+++ b/src/sphinx_graph/vertex/state.py
@@ -45,9 +45,11 @@ def purge(_app: Sphinx, env: BuildEnvironment, docname: str) -> None:
     If there are vertices left in the document, they will be added again during parsing.
     """
     with _vertices_tmp(env) as vertices:
-        vertices = {  # noqa: PLW2901
+        filtered_vertices = {
             uid: vert for uid, vert in vertices.items() if vert.docname != docname
         }
+        vertices.clear()
+        vertices.update(filtered_vertices)
 
 
 def merge(


### PR DESCRIPTION
## Summary
- update the purge helper to mutate the temporary vertex mapping in place
- add a regression test that verifies purge removes stale vertices while preserving shared references

## Testing
- pytest tests/test_graph.py::test_purge_removes_stale_vertices *(fails: missing sphinx dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3f7e922a0832a98c81ba5e1f9087c