### PR TITLE
Prevent custom table queries from leaking between builds

### DIFF
--- a/src/sphinx_graph/table/events.py
+++ b/src/sphinx_graph/table/events.py
@@ -56,8 +56,7 @@ def process(app: Sphinx, doctree: nodes.document, _fromdocname: str) -> None:
     builder = app.builder
     state = State.read(app.env)
     vertex_state = vertex.State.read(app.env)
-    queries = QUERIES
-    queries.update(app.config.graph_config.queries)
+    queries = {**QUERIES, **app.config.graph_config.queries}
     for node in doctree.findall(TableNode):
         uid = node["graph_uid"]
         info = state.tables[uid]

--- a/tests/roots/test-table-query-alt/conf.py
+++ b/tests/roots/test-table-query-alt/conf.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+from sphinx_graph import Config
+
+sys.path.append(str(Path.cwd()))
+
+from queries import siblings
+
+graph_config = Config(queries={"siblings": siblings})
+
+extensions = [
+    "sphinx_graph",
+]

--- a/tests/roots/test-table-query-alt/index.rst
+++ b/tests/roots/test-table-query-alt/index.rst
@@ -1,0 +1,18 @@
+.. vertex:: 01
+
+   this is a vertex directive
+
+.. vertex:: 02
+   :parents: 01
+
+   this is a vertex directive
+
+.. vertex:: 03
+   :parents: 01
+
+   this is a vertex directive
+
+.. vertex-table::
+   :query: siblings
+
+   uid = "02"

--- a/tests/roots/test-table-query-alt/queries/__init__.py
+++ b/tests/roots/test-table-query-alt/queries/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sphinx_graph.vertex import State
+
+
+def siblings(state: State, *, uid: str, include_self: bool = False) -> Iterable[str]:
+    """Return the siblings of a vertex, optionally including the vertex itself."""
+    parents = state.vertices[uid].parents
+    for parent in parents:
+        for child in state.children(parent):
+            if include_self or child != uid:
+                yield child


### PR DESCRIPTION
## Summary
- copy the default query mapping when processing vertex tables to avoid mutating shared state
- add a regression test that builds two projects with different query maps to verify isolation
- introduce a second table-query Sphinx root used by the new regression test

## Testing
- pytest tests/test_table.py *(fails: missing sphinx package in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3f7ac64e4832a97bd4f755433d5ae