### PR TITLE
Handle missing vertex state for empty roots

### DIFF
--- a/src/sphinx_graph/vertex/state.py
+++ b/src/sphinx_graph/vertex/state.py
@@ -75,7 +75,7 @@ def build_and_check_graph(env: BuildEnvironment) -> State:
 
     Also checks the graph for consistency.
     """
-    vertices_tmp: dict[str, Info] = env.graph_vertices_tmp  # type: ignore[attr-defined]
+    vertices_tmp: dict[str, Info] = getattr(env, "graph_vertices_tmp", {})
     vertices: dict[str, tuple[int, Info]] = {}
     graph: rx.PyDiGraph[str, str | None] = rx.PyDiGraph()
 

--- a/tests/roots/test-empty/conf.py
+++ b/tests/roots/test-empty/conf.py
@@ -1,0 +1,3 @@
+extensions = [
+    "sphinx_graph",
+]

--- a/tests/roots/test-empty/index.rst
+++ b/tests/roots/test-empty/index.rst
@@ -1,0 +1,4 @@
+Empty project
+=============
+
+This root contains no vertex directives.

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -7,6 +7,11 @@ from sphinx.errors import SphinxError
 from sphinx_graph import vertex
 
 
+@pytest.mark.sphinx(testroot="empty", warningiserror=True)
+def test_empty_project_builds(app: Sphinx) -> None:
+    app.build()
+
+
 @pytest.mark.sphinx(testroot="vertex", warningiserror=True)
 def test_it_builds(app: Sphinx) -> None:
     app.build()


### PR DESCRIPTION
## Summary
- default the vertex graph builder to an empty mapping when the environment lacks temporary vertices
- add an empty Sphinx root and regression test ensuring vertex processing succeeds with no directives present

## Testing
- pytest tests/test_vertex.py::test_empty_project_builds -q *(fails: No module named 'sphinx')*

------
https://chatgpt.com/codex/tasks/task_e_68f3f7bbd230832a8120e57e3ee8dedc